### PR TITLE
Add multicore support

### DIFF
--- a/Klib/GMblob.py
+++ b/Klib/GMblob.py
@@ -1,12 +1,58 @@
-
 from pathlib import Path
 import os
 from subprocess import Popen, PIPE, DEVNULL
-from struct import pack,unpack
+from struct import pack, unpack
 from time import sleep
 import sys
+from multiprocessing import Pool
+import tempfile
+import multiprocessing
 
 MIN_SIZE = 1024*1024 # 1 MB
+
+# Helper function for parallel compression
+def compress_audio(args):
+    """Compress a single audio entry to OGG using oggenc/oggdec."""
+    audiogroup_id, audo_entry, input_path, compress, oggenc_options, output_path, verbose = args
+    try:
+        with open(input_path, 'rb') as temp_in:
+            input_data = temp_in.read()
+        with open(output_path, 'wb') as temp_out:
+            oggenc_process = Popen(
+                ["oggenc", "-Q", *oggenc_options, "-o", "-", "-"],
+                stdin=PIPE,
+                stdout=temp_out,
+                stderr=DEVNULL
+            )
+            if compress > 1:  # Recompress OGG
+                oggdec_process = Popen(
+                    ["oggdec", "-Q", "-o", "-", "-"],
+                    stdin=PIPE,
+                    stdout=PIPE,
+                    stderr=DEVNULL
+                )
+                wavdata, _ = oggdec_process.communicate(input_data)
+                oggenc_process.communicate(wavdata)
+                oggdec_process.terminate()
+            else:  # Compress WAV
+                oggenc_process.communicate(input_data)
+            oggenc_process.terminate()
+        if verbose > 1:
+            print(f"[AGRP {audiogroup_id}] Compressed AUDO entry {audo_entry} to {output_path}")
+            sys.stdout.flush()
+        with open(output_path, 'rb') as temp_out:
+            return audiogroup_id, audo_entry, temp_out.read()
+    except Exception as e:
+        if verbose > 0:
+            print(f"[AGRP {audiogroup_id}] Error compressing AUDO entry {audo_entry}: {str(e)}")
+            sys.stdout.flush()
+        return audiogroup_id, audo_entry, None
+    finally:
+        try:
+            os.remove(input_path)
+            os.remove(output_path)
+        except OSError:
+            pass
 
 class IFFdata:
 
@@ -150,7 +196,7 @@ class IFFdata:
 
 class GMIFFDdata(IFFdata):
 
-    def __init__(self, fin_path, verbose, audiosettings={"bitrate": 0, "downmix": False, "resample": 0}, audiogroup_id=0):
+    def __init__(self, fin_path, verbose, audiosettings={"bitrate": 0, "downmix": False, "resample": 0}, audiogroup_id=0, cores=0):
         super().__init__(fin_path, verbose)
         
         self.audo = None
@@ -160,6 +206,8 @@ class GMIFFDdata(IFFdata):
         self.updated_entries = 0
         self.no_write = False
 
+        self.cores = cores if cores > 0 else multiprocessing.cpu_count()
+        
         self.__init_audo()
     
     def __init_audo(self):
@@ -217,7 +265,7 @@ class GMIFFDdata(IFFdata):
         
         return total
 
-    def _write_to_file_audo(self):
+    def _write_to_file_audo(self, compressed_data=None):
         self.filein.seek(self.chunk_list["AUDO"]["offset"])
         size = self.chunk_list["AUDO"]["size"]
         self._vvprint(f"[AGRP {self.audiogroup_id}] Writing AUDO")
@@ -232,31 +280,28 @@ class GMIFFDdata(IFFdata):
 
         else:
             self._vvprint(f"[AGRP {self.audiogroup_id}] Rebuild AUDO")
-            self.fileout.write(self.filein.read(4)) # Token should be the same
+            self.fileout.write(self.filein.read(4))  # Token
             self.fileout_size += 4
-            self.fileout.write(pack('<I', 0xffffffff)) # Unknow size yet
+            self.fileout.write(pack('<I', 0xffffffff))  # Unknown size yet
             self.fileout_size += 4
 
-            self.fileout.write(pack('<I', len(self.audo.keys()))) # Number of audo entries
+            self.fileout.write(pack('<I', len(self.audo.keys())))  # Number of entries
             self.fileout_size += 4
 
             table_offset = self.fileout.tell()
 
-            self.fileout.write(pack('<I', 0xffffffff) * len(self.audo.keys())) # offset entries are unknow yet
+            self.fileout.write(pack('<I', 0xffffffff) * len(self.audo.keys()))  # Placeholder offsets
             self.fileout_size += 4 * len(self.audo.keys())
                                          
             padding = self._get_padding(16)
             
-            self.fileout.write(b'\x00' * padding )
+            self.fileout.write(b'\x00' * padding)
             self.fileout_size += padding
 
             for n, key in enumerate(self.audo.keys()):
-                entrysize = self.audo[key]["size"]
-
-                # update entry table
                 current_offset = self.fileout.tell()
-                self.fileout.seek(table_offset + 4*n)
-                self.fileout.write(pack('<I',current_offset))
+                self.fileout.seek(table_offset + 4 * n)
+                self.fileout.write(pack('<I', current_offset))
                 self.fileout.seek(current_offset)
 
 
@@ -266,38 +311,33 @@ class GMIFFDdata(IFFdata):
 
 
                     # We copy the entry from the input file
-                    self.fileout.write(self.filein.read(4 + entrysize )) # same entry (4B size + audio size)
-                    self.fileout_size += 4 + entrysize
-
+                    self.fileout.write(self.filein.read(4 + self.audo[key]["size"]))  # same entry (4B size + audio size)
+                    self.fileout_size += 4 + self.audo[key]["size"]
                 elif self.audo[key]["compress"] > 0 and self.audo[key]["source"] == "infile":
-                    self._vvprint(f"[AGRP {self.audiogroup_id}] Compress AUDO entry {key}")
-
-                    self.fileout.write(pack('<I', 0xffffffff) ) # unknow size yet
-                    self.fileout_size += 4
-
-                    entrysize = self._write_to_file_audo_ogg(key,self.audo[key]["compress"])
-                    self.fileout_size += entrysize
-
-                    self.fileout.seek( -entrysize - 4 , 1)
-                    self.fileout.write(pack('<I', entrysize) )
-                    self.fileout.seek( entrysize , 1)
-
+                    self._vvprint(f"[AGRP {self.audiogroup_id}] Writing compressed AUDO entry {key}")
+                    compressed = compressed_data.get((self.audiogroup_id, key))
+                    if compressed is None:
+                        self._vprint(f"[AGRP {self.audiogroup_id}] Skipping AUDO entry {key} due to compression error")
+                        self.fileout.write(pack('<I', 0))  # Write zero size
+                        self.fileout_size += 4
+                    else:
+                        entrysize = len(compressed)
+                        self.fileout.write(pack('<I', entrysize))
+                        self.fileout.write(compressed)
+                        self.fileout_size += 4 + entrysize
                 elif self.audo[key]["compress"] > 0 and self.audo[key]["source"] == "txtp":
                     self._vvprint(f"[AGRP {self.audiogroup_id}] Compress TXTP external sound {key}")
-
-                    self.fileout.write(pack('<I', 0xffffffff) ) # unknow size yet
+                    self.fileout.write(pack('<I', 0xffffffff))  # Unknown size
                     self.fileout_size += 4
 
                     entrysize = self._write_to_file_txtp_ogg(key)
                     self.fileout_size += entrysize
-
-                    self.fileout.seek( -entrysize - 4 , 1)
-                    self.fileout.write(pack('<I', entrysize) )
-                    self.fileout.seek( entrysize , 1)
+                    self.fileout.seek(-entrysize - 4, 1)
+                    self.fileout.write(pack('<I', entrysize))
+                    self.fileout.seek(entrysize, 1)
 
                 padding = self._get_padding(16)
-            
-                self.fileout.write(b'\x00' * padding )
+                self.fileout.write(b'\x00' * padding)
                 self.fileout_size += padding
 
             audo_size = self.fileout_size - audo_offset - 8
@@ -338,14 +378,8 @@ class GMIFFDdata(IFFdata):
         return self.fileout.tell() - offset_start
 
     def _write_to_file_audo_ogg(self, audo_entry, compress):
-
-        offset_start = self.fileout.tell()
-        self.fileout.seek(offset_start)                 # Can't find out why, but if I don't do this
-                                                        # it writes with -4 bytes offset...
-
-        self.filein.seek(4 + self.audo[audo_entry]["offset"])
-
-        oggenc_process = Popen(["oggenc", "-Q", *self._get_oggenc_options(), "-o", "-", "-"], stdin=PIPE, stdout=self.fileout, stderr=DEVNULL)
+        # Deprecated: Replaced by parallel compress_audio
+        raise NotImplementedError("Use parallel compression in _write_to_file_audo")
 
         if compress > 1:
             # audio is already compressed, we need to uncompress it before can compress it
@@ -394,8 +428,8 @@ class GMIFFDdata(IFFdata):
 
 class GMaudiogroup(GMIFFDdata):
 
-    def __init__(self, fin_path, verbose, audiosettings, audiogroup_id):
-        super().__init__(fin_path, verbose, audiosettings, audiogroup_id)
+    def __init__(self, fin_path, verbose, audiosettings, audiogroup_id, cores=0):
+        super().__init__(fin_path, verbose, audiosettings, audiogroup_id, cores)
     
     def import_sound_txtp(self, filetxtp_path, compress=0 ):
         last = len(self.audo)
@@ -403,7 +437,7 @@ class GMaudiogroup(GMIFFDdata):
         self.chunk_list["FORM"]["rebuild"] = 1
         self.chunk_list["AUDO"]["rebuild"] = 1
 
-    def write_changes(self, OUT_DIR):
+    def write_changes(self, OUT_DIR, compressed_data=None):
         if self.no_write:
             self._vprint(f"No write set for AGRP {self.audiogroup_id}: Will not write {self.filein_path.name}")
         else:
@@ -413,14 +447,14 @@ class GMaudiogroup(GMIFFDdata):
 
             if self.chunk_list["FORM"]["rebuild"] == 1:
 
-                for _,token in enumerate(self.chunk_list):
+                for _, token in enumerate(self.chunk_list):
                     if token == "AUDO":
-                        self._write_to_file_audo()
+                        self._write_to_file_audo(compressed_data)
                     else:
                         self._write_to_file_otherchunk(token)
 
                 self.fileout.seek(4)
-                self.fileout.write(pack('<I', self.fileout_size - 8)) # update size
+                self.fileout.write(pack('<I', self.fileout_size - 8))  # Update size
             else:
                 self._write_to_file_otherchunk("FORM")
 
@@ -429,8 +463,8 @@ class GMdata(GMIFFDdata):
     GM_DEFAULT = 0x0000
     GM_2024_6 = 0x1806
 
-    def __init__(self, fin_path, verbose, audiosettings, audiogroup_filter=[]):
-        super().__init__(fin_path, verbose, audiosettings, 0)
+    def __init__(self, fin_path, verbose, audiosettings, audiogroup_filter=[], cores=0):
+        super().__init__(fin_path, verbose, audiosettings, 0, cores)
         self.gm_version = GMdata.GM_DEFAULT
 
         self.sond = None
@@ -512,7 +546,13 @@ class GMdata(GMIFFDdata):
     
     def __init_audiogroup_dat(self, audiogroup):
         if audiogroup > 0 and not f"{audiogroup}" in self.audiogroup_dat.keys():
-            self.audiogroup_dat[f"{audiogroup}"] = GMaudiogroup(self.filein_path.parents[0] / f"audiogroup{audiogroup}.dat" , self.verbose, self.audiosettings, audiogroup)
+            self.audiogroup_dat[f"{audiogroup}"] = GMaudiogroup(
+                self.filein_path.parents[0] / f"audiogroup{audiogroup}.dat",
+                self.verbose,
+                self.audiosettings,
+                audiogroup,
+                self.cores
+            )
  
     def __sond_get_raw_entry(self,key):
 
@@ -606,35 +646,87 @@ class GMdata(GMIFFDdata):
         if self.gm_version == GMdata.GM_2024_6:
             self._vprint("GM 2024.6 detected")
     
-    def audio_enable_compress(self ,minsize, recompress=False):
+    def audio_enable_compress(self, minsize, recompress=False):
+        tasks = []
+        temp_files = []
 
-        # Iter each entry in SOND
-        for _,sond_key in enumerate(self.sond):
+        # Prepare tasks for all audiogroups
+        for _, sond_key in enumerate(self.sond):
             audiogroup_id = self.sond[sond_key]["audiogroup"]           # it is an audiogroup ID (eg 0 or 1)
-            audiofile_id = self.sond[sond_key]['audiofile']
+            audiofile_id = self.sond[sond_key]["audiofile"]
 
             if audiofile_id == 0xffffffff:
                 # AUDO entry doesn't exist
                 continue
 
             audiofile = f"{audiofile_id:#04}"    # it is a file number (eg 0001)
-            size = self._audo_get_size(audiogroup_id, audiofile)
 
-            if ( audiogroup_id in self.audiogroup_filter or len(self.audiogroup_filter) == 0) and size >= minsize:
-                if self.sond[sond_key]["flags"]["isCompressed"] == 0:
-                    self.__sond_set_compress(sond_key)
-                    self._audo_set_compress(audiogroup_id, audiofile)
-                
-                    self._vvprint(f"audo {audiofile} in audiogroup {audiogroup_id} ({self.sond[sond_key]['name']}) with size {self._pretty_size(size)} will be compressed")
+            if (audiogroup_id in self.audiogroup_filter or len(self.audiogroup_filter) == 0):
+                size = self._audo_get_size(audiogroup_id, audiofile)
+                if size >= minsize:
+                    if self.sond[sond_key]["flags"]["isCompressed"] == 0:
+                        self.__sond_set_compress(sond_key)
+                        self._audo_set_compress(audiogroup_id, audiofile)
+                        input_path = tempfile.mktemp()
+                        output_path = tempfile.mktemp()
+                        with open(input_path, 'wb') as temp_in:
+                            if audiogroup_id == 0:
+                                self.filein.seek(4 + self.audo[audiofile]["offset"])
+                                temp_in.write(self.filein.read(self.audo[audiofile]["size"]))
+                            else:
+                                ag = self.audiogroup_dat[f"{audiogroup_id}"]
+                                ag.filein.seek(4 + ag.audo[audiofile]["offset"])
+                                temp_in.write(ag.filein.read(ag.audo[audiofile]["size"]))
+                        tasks.append((
+                            audiogroup_id,
+                            audiofile,
+                            input_path,
+                            1,  # Compress WAV
+                            self._get_oggenc_options(),
+                            output_path,
+                            self.verbose
+                        ))
+                        temp_files.extend([input_path, output_path])
+                        self._vvprint(f"audo {audiofile} in audiogroup {audiogroup_id} ({self.sond[sond_key]['name']}) with size {self._pretty_size(size)} will be compressed")
+                    elif recompress and size >= minsize:
+                        self._audo_set_recompress(audiogroup_id, audiofile)
+                        input_path = tempfile.mktemp()
+                        output_path = tempfile.mktemp()
+                        with open(input_path, 'wb') as temp_in:
+                            if audiogroup_id == 0:
+                                self.filein.seek(4 + self.audo[audiofile]["offset"])
+                                temp_in.write(self.filein.read(self.audo[audiofile]["size"]))
+                            else:
+                                ag = self.audiogroup_dat[f"{audiogroup_id}"]
+                                ag.filein.seek(4 + ag.audo[audiofile]["offset"])
+                                temp_in.write(ag.filein.read(ag.audo[audiofile]["size"]))
+                        tasks.append((
+                            audiogroup_id,
+                            audiofile,
+                            input_path,
+                            2,  # Recompress OGG
+                            self._get_oggenc_options(),
+                            output_path,
+                            self.verbose
+                        ))
+                        temp_files.extend([input_path, output_path])
+                        self._vvprint(f"audo {audiofile} in audiogroup {audiogroup_id} ({self.sond[sond_key]['name']}) with size {self._pretty_size(size)} will be recompressed")
 
-                elif recompress and size >= minsize:
-                    self._audo_set_recompress(audiogroup_id, audiofile)
-                
-                    self._vvprint(f"audo {audiofile} in audiogroup {audiogroup_id} ({self.sond[sond_key]['name']}) with size {self._pretty_size(size)} will be recompressed")
+        # Execute compression tasks in parallel
+        compressed_data = {}
+        if tasks:
+            self._vprint(f"Compressing {len(tasks)} audio entries across all audiogroups using {self.cores} cores")
+            with Pool(processes=self.cores) as pool:
+                results = pool.map(compress_audio, tasks)
+            for audiogroup_id, audiofile, data in results:
+                if data is not None:
+                    compressed_data[(audiogroup_id, audiofile)] = data
 
         if self.get_total_updated_entries() > 0:
             # toggle rebuild because we will update data
             self._vprint(f"{self.get_total_updated_entries()} audo entrie(s) will be compressed")
+
+        self.compressed_data = compressed_data
 
     def write_changes(self, OUT_DIR):
         if self.no_write:
@@ -646,20 +738,18 @@ class GMdata(GMIFFDdata):
             self._open_fileout()
 
             if self.chunk_list["FORM"]["rebuild"] == 1:
-
-                for _,token in enumerate(self.chunk_list):
+                for _, token in enumerate(self.chunk_list):
                     if token == "SOND":
                         self.__write_to_file_sond()
                     elif token == "AUDO":
-                        self._write_to_file_audo()
+                        self._write_to_file_audo(self.compressed_data)
                     else:
                         self._write_to_file_otherchunk(token)
-
                 self.fileout.seek(4)
-                self.fileout.write(pack('<I', self.fileout_size - 8)) # update size
+                self.fileout.write(pack('<I', self.fileout_size - 8))  # Update size
             else:
                 self._write_to_file_otherchunk("FORM")
         
         # also write audiogroupN.dat files
-        for _,key in enumerate(self.audiogroup_dat.keys()):
-            self.audiogroup_dat[key].write_changes(OUT_DIR)
+        for _, key in enumerate(self.audiogroup_dat.keys()):
+            self.audiogroup_dat[key].write_changes(OUT_DIR, self.compressed_data)

--- a/gmKtool.py
+++ b/gmKtool.py
@@ -7,30 +7,29 @@
     usage: ./gm-Ktool.py data.win -d ./repacked -a 0 -a 1 -m 524288
             Will compress all wav data > 512 KB in audiogroup 0 (data.win) and 1 (audiogroup1.dat)
             The updated files will be written in ./repacked
-            -d, -a and -m are optionnal
+            -d, -a and -m are optional
 """
 import argparse
 from pathlib import Path
 from Klib.GMblob import GMdata
 
-MIN_SIZE = 1024*1024 # 1 MB
+MIN_SIZE = 1024*1024  # 1 MB
 
 def main():
-
-
     parser = argparse.ArgumentParser(description='GameMaker K-dog tool: compress wav to ogg, recompress ogg, in Gamemaker data files')
     parser.add_argument('-v', '--verbose', action='count', default=0, help='Verbose level (cumulative option)')
     parser.add_argument('-m', '--minsize', default=MIN_SIZE, type=int, help='Minimum WAV/OGG size in bytes to target (default 1MB)')
-    parser.add_argument('-a', '--audiogroup', nargs='?',action='append',type=int, help='Audiogroup ID to process (option can repeat). By default any.')
-    parser.add_argument('-N', '--no-write', nargs="?",action='append', type=int, help='Don\'t write the updated file for this audiogroup number (option can repeat). By default none.')
-    parser.add_argument('-O', '--only-write', nargs="?",action='append', type=int, help='Only write the updated file for this audiogroup number (option can repeat). By default write all.')
-    parser.add_argument('-b', '--bitrate', default=0, type=int, help='nominal bitrate (in kbps) to encode at (oggenc -b option). 0 for auto (default)')
+    parser.add_argument('-a', '--audiogroup', nargs='?', action='append', type=int, help='Audiogroup ID to process (option can repeat). By default any.')
+    parser.add_argument('-N', '--no-write', nargs="?", action='append', type=int, help='Don\'t write the updated file for this audiogroup number (option can repeat). By default none.')
+    parser.add_argument('-O', '--only-write', nargs="?", action='append', type=int, help='Only write the updated file for this audiogroup number (option can repeat). By default write all.')
+    parser.add_argument('-b', '--bitrate', default=0, type=int, help='Nominal bitrate (in kbps) to encode at (oggenc -b option). 0 for auto (default)')
     parser.add_argument('-D', '--downmix', default=False, action='store_true', help='Downmix stereo to mono (oggenc --downmix option)')
     parser.add_argument('-R', '--resample', default=0, type=int, help='Resample input data to sampling rate n (Hz) (oggenc --resample option). Supported values: 8000, 11025, 22050, 32000, 44100, 48000')
     parser.add_argument('-B', '--buffered', default=False, action='store_true', help='Don\'t flush stdout after each line (incompatible with the patcher screen)')
     parser.add_argument('-r', '--recompress', default=False, action='store_true', help='Allow ogg recompression')
     parser.add_argument('-y', '--yes', default=False, action='store_true', help='Overwrite the files if already present without asking (DANGEROUS, use with caution)')
-    parser.add_argument('-d', '--destdirpath', default="./Ktool.out",help='Destination directory path (default ./Ktool.out)')
+    parser.add_argument('-d', '--destdirpath', default="./Ktool.out", help='Destination directory path (default ./Ktool.out)')
+    parser.add_argument('-c', '--cores', default=0, type=int, help='Number of CPU cores to use for compression (0 for auto, default 0)')
 
     parser.add_argument('infilepath', help='Input file path (eg: data.win)')
 
@@ -40,7 +39,7 @@ def main():
         print("-N and -O are incompatible together, use only one")
         exit(1)
 
-    if not args.resample in [ 0, 8000, 11025, 22050, 32000, 44100, 48000 ]:
+    if not args.resample in [0, 8000, 11025, 22050, 32000, 44100, 48000]:
         print("-R supported values are 8000, 11025, 22050, 32000, 44100, 48000")
         exit(1)
 
@@ -49,8 +48,8 @@ def main():
     else:
         audiogroup_filter = []
 
-    INFILE_PATH=Path(args.infilepath)
-    OUT_DIR=Path(args.destdirpath)
+    INFILE_PATH = Path(args.infilepath)
+    OUT_DIR = Path(args.destdirpath)
 
     if not INFILE_PATH.exists():
         print(f"{INFILE_PATH} not found")
@@ -59,7 +58,7 @@ def main():
     if OUT_DIR.exists():
         if OUT_DIR.is_dir():
             if any(OUT_DIR.iterdir()) and not args.yes:
-                answer=input(f"{OUT_DIR} already exists and contains file. Do you want to continue? (y/n)")
+                answer = input(f"{OUT_DIR} already exists and contains files. Do you want to continue? (y/n)")
                 if not answer in 'yY':
                     exit(0)
         else:
@@ -68,21 +67,21 @@ def main():
     else:
         OUT_DIR.mkdir()
 
-    audiosettings = {}
-    audiosettings["bitrate"] = args.bitrate
-    audiosettings["downmix"] = args.downmix
-    audiosettings["resample"] = args.resample
+    audiosettings = {
+        "bitrate": args.bitrate,
+        "downmix": args.downmix,
+        "resample": args.resample
+    }
 
-    myiffdata = GMdata(INFILE_PATH, args.verbose, audiosettings, audiogroup_filter)
+    myiffdata = GMdata(INFILE_PATH, args.verbose, audiosettings, audiogroup_filter, args.cores)
 
-    if  args.no_write != None:
+    if args.no_write != None:
         myiffdata.no_write(args.no_write)
     elif args.only_write != None:
         myiffdata.only_write(args.only_write)
 
     myiffdata.set_buffered(args.buffered)
-
-    myiffdata.audio_enable_compress(args.minsize,args.recompress)
+    myiffdata.audio_enable_compress(args.minsize, args.recompress)
     myiffdata.write_changes(OUT_DIR)
 
     exit(0)


### PR DESCRIPTION
Added partial multicore support to GMblob.py for parallel WAV/OGG compression across audiogroups using `multiprocessing.Pool`. Still builds the dictionary and writes sequentially, but performs compression with cores specified in arguments `-c` or auto. Estimate ~68% reduction in processing time.

UFO50 was tested with the Retroid Pocket 5. It used all 8 cores and took approximately 1m24s to fully patch a new install. An existing install took approximately 55s.